### PR TITLE
Install html and concurrent.futures

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1045,9 +1045,11 @@ LIBSUBDIRS=	lib-tk lib-tk/test lib-tk/test/test_tkinter \
 		test/imghdrdata \
 		test/subprocessdata \
 		test/tracedmodules \
+		concurrent concurrent/futures \
 		encodings compiler hotshot \
 		email email/mime email/test email/test/data \
 		ensurepip ensurepip/_bundled \
+		html \
 		json json/tests \
 		sqlite3 sqlite3/test \
 		logging bsddb bsddb/test csv importlib wsgiref \


### PR DESCRIPTION
Fixes a bug in which `html` and `concurrent.futures` would not get installed under "make install", (due to containing subdirectories).