### PR TITLE
Nonlocal tests

### DIFF
--- a/Include/opcode.h
+++ b/Include/opcode.h
@@ -154,6 +154,7 @@ extern "C" {
 #define LOAD_CLOSURE    135     /* Load free variable from closure */
 #define LOAD_DEREF      136     /* Load and dereference from closure cell */ 
 #define STORE_DEREF     137     /* Store into cell */ 
+#define DELETE_DEREF    138     /* Delete closure cell */
 
 /* The next 3 opcodes must be contiguous and satisfy
    (CALL_FUNCTION_VAR - CALL_FUNCTION) & 3 == 1  */

--- a/Lib/opcode.py
+++ b/Lib/opcode.py
@@ -187,6 +187,8 @@ def_op('LOAD_DEREF', 136)
 hasfree.append(136)
 def_op('STORE_DEREF', 137)
 hasfree.append(137)
+def_op('DELETE_DEREF', 138)
+hasfree.append(138)
 
 def_op('CALL_FUNCTION_VAR', 140)     # #args + (#kwargs << 8)
 def_op('CALL_FUNCTION_KW', 141)      # #args + (#kwargs << 8)

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -401,6 +401,17 @@ class ExceptionTests(unittest.TestCase):
         self.assertTrue(unicode(Exception(u'a')))
         self.assertTrue(unicode(Exception(u'\xe1')))
 
+    def test_exception_target_in_nested_scope(self):
+        # issue 4617: This used to raise a SyntaxError
+        # "can not delete variable 'e' referenced in nested scope"
+        def print_error():
+            e
+        try:
+            something
+        except Exception as e:
+            print_error()
+            # implicit "del e" here
+
     def testUnicodeChangeAttributes(self):
         # See issue 7309. This was a crasher.
 

--- a/Lib/test/test_scope.py
+++ b/Lib/test/test_scope.py
@@ -228,13 +228,6 @@ def error(y):
 """)
 
         check_syntax_error(self, """\
-def f(x):
-    def g():
-        return x
-    del x # can't del name
-""")
-
-        check_syntax_error(self, """\
 def f():
     def g():
         from string import *
@@ -301,6 +294,28 @@ def noproblem3():
         self.assertRaises(UnboundLocalError, errorInOuter)
         self.assertRaises(NameError, errorInInner)
 
+    def testUnboundLocal_AfterDel(self):
+        # #4617: It is now legal to delete a cell variable.
+        # The following functions must obviously compile,
+        # and give the correct error when accessing the deleted name.
+        def errorInOuter():
+            y = 1
+            del y
+            print(y)
+            def inner():
+                return y
+
+        def errorInInner():
+            def inner():
+                return y
+            y = 1
+            del y
+            inner()
+
+        self.assertRaises(UnboundLocalError, errorInOuter)
+        self.assertRaises(NameError, errorInInner)
+
+    def testUnboundLocal_AugAssign(self):
         # test for bug #1501934: incorrect LOAD/STORE_GLOBAL generation
         exec """
 global_x = 1

--- a/Lib/test/test_super.py
+++ b/Lib/test/test_super.py
@@ -45,11 +45,10 @@ class G(A):
 
 class TestSuper(unittest.TestCase):
 
-    # TODO/RSI for when have nonlocal
-    #def tearDown(self):
-    #    # This fixes the damage that test_various___class___pathologies does.
-    #    nonlocal __class__
-    #    __class__ = TestSuper
+    def tearDown(self):
+        # This fixes the damage that test_various___class___pathologies does.
+        nonlocal __class__
+        __class__ = TestSuper
 
     def test_basics_working(self):
         self.assertEqual(D().f(), 'ABCD')
@@ -116,13 +115,12 @@ class TestSuper(unittest.TestCase):
         self.assertEqual(globals()["__class__"], 42)
         del globals()["__class__"]
         self.assertNotIn("__class__", X.__dict__)
-        # TODO/RSI for when have nonlocal
-        #class X:
-        #    nonlocal __class__
-        #    __class__ = 42
-        #    def f():
-        #        __class__
-        #self.assertEqual(__class__, 42)
+        class X:
+            nonlocal __class__
+            __class__ = 42
+            def f():
+                __class__
+        self.assertEqual(__class__, 42)
 
     def test___class___instancemethod(self):
         # See issue #14857
@@ -155,13 +153,12 @@ class TestSuper(unittest.TestCase):
             del x
             super()
         self.assertRaises(RuntimeError, f, None)
-        # TODO/RSI for when have nonlocal
-        #class X:
-        #    def f(x):
-        #        nonlocal __class__
-        #        del __class__
-        #        super()
-        #self.assertRaises(RuntimeError, X().f)
+        class X:
+            def f(x):
+                nonlocal __class__
+                del __class__
+                super()
+        self.assertRaises(RuntimeError, X().f)
 
     def test_cell_as_self(self):
         class X:

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -600,15 +600,6 @@ class SyntaxTestCase(unittest.TestCase):
     def test_break_outside_loop(self):
         self._check_error("break", "outside loop")
 
-    def test_delete_deref(self):
-        source = re.sub('(?m)^ *:', '', """\
-            :def foo(x):
-            :  def bar():
-            :    print x
-            :  del x
-            :""")
-        self._check_error(source, "nested scope")
-
     def test_unexpected_indent(self):
         self._check_error("foo()\n bar()\n", "unexpected indent",
                           subclass=IndentationError)

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -968,6 +968,8 @@ opcode_stack_effect(int opcode, int oparg)
             return 1;
         case STORE_DEREF:
             return -1;
+        case DELETE_DEREF:
+            return 0;
         case GET_AWAITABLE:
             return 0;
         case SETUP_ASYNC_WITH:
@@ -2794,13 +2796,7 @@ compiler_nameop(struct compiler *c, identifier name, expr_context_ty ctx)
         case AugLoad:
         case AugStore:
             break;
-        case Del:
-            PyErr_Format(PyExc_SyntaxError,
-                         "can not delete variable '%s' referenced "
-                         "in nested scope",
-                         PyString_AS_STRING(name));
-            Py_DECREF(mangled);
-            return 0;
+        case Del: op = DELETE_DEREF; break;
         case Param:
         default:
             PyErr_SetString(PyExc_SystemError,

--- a/Python/opcode_targets.h
+++ b/Python/opcode_targets.h
@@ -137,7 +137,7 @@ static void *opcode_targets[256] = {
     &&TARGET_LOAD_CLOSURE,
     &&TARGET_LOAD_DEREF,
     &&TARGET_STORE_DEREF,
-    &&_unknown_opcode,
+    &&TARGET_DELETE_DEREF,
     &&_unknown_opcode,
     &&TARGET_CALL_FUNCTION_VAR,
     &&TARGET_CALL_FUNCTION_KW,


### PR DESCRIPTION
Added nonlocal back into test_super and test_coroutines, (closes #44). Deleting the `__class__` variable in test_super required also backporting the ability to delete variables in nested scopes, (f4136c2c8).